### PR TITLE
Add the plugin to `recently_active` plugins list if self-deactivating.

### DIFF
--- a/debug-bar-screen-info.php
+++ b/debug-bar-screen-info.php
@@ -39,10 +39,21 @@ if ( ! function_exists( 'dbsi_has_parent_plugin' ) ) {
 	 * Show notice & de-activate itself if debug-bar plugin not active.
 	 */
 	function dbsi_has_parent_plugin() {
-		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) ) {
+		$file = plugin_basename( __FILE__ );
+
+		if ( is_admin() && ( ! class_exists( 'Debug_Bar' ) && current_user_can( 'activate_plugins' ) ) && is_plugin_active( $file ) ) {
 			add_action( 'admin_notices', create_function( null, 'echo \'<div class="error"><p>\', sprintf( __( \'Activation failed: Debug Bar must be activated to use the <strong>Debug Bar Screen Info</strong> Plugin. <a href="%s">Visit your plugins page to activate</a>.\', \'debug-bar-screen-info\' ), admin_url( \'plugins.php#debug-bar\' ) ), \'</p></div>\';' ) );
 
-			deactivate_plugins( plugin_basename( __FILE__ ) );
+			deactivate_plugins( $file, false, is_network_admin() );
+
+			// Add to recently active plugins list.
+			if ( ! is_network_admin() ) {
+				update_option( 'recently_activated', array( $file => time() ) + (array) get_option( 'recently_activated' ) );
+			} else {
+				update_site_option( 'recently_activated', array( $file => time() ) + (array) get_site_option( 'recently_activated' ) );
+			}
+
+			// Prevent trying again on page reload.
 			if ( isset( $_GET['activate'] ) ) {
 				unset( $_GET['activate'] );
 			}


### PR DESCRIPTION
Also: only try to deactivate if it's a 'normal' plugin, i.e. not a must-use plugin. This prevents the admin notice showing up on every page if the Debug Bar plugin is not active and this plugin is in the must-use directory.

Compatible with multi-site/network (de-)activation.