### PR TITLE
QA update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,26 +24,28 @@ matrix:
     - php: '7.0'
     # aliased to a recent 7.1.x version
     - php: '7.1'
-    # aliased to a recent hhvm version
-    - php: 'hhvm'
+    # bleeding edge
+    - php: 'nightly'
 
   allow_failures:
-    - php: 'hhvm'
+    - php: 'nightly'
 
-before_script:
-  - export PHPCS_DIR=/tmp/phpcs
-  - export SNIFFS_DIR=/tmp/sniffs
-  # Install CodeSniffer for WordPress Coding Standards checks.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
-  # Install WordPress Coding Standards.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
-  # Install PHP Compatibility sniffs.
-  - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
-  # Set install path for PHPCS sniffs.
-  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
-  - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
-  # After CodeSniffer install you should refresh your path.
-  - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
+before_install:
+    - export PHPCS_DIR=/tmp/phpcs
+    - export SNIFFS_DIR=/tmp/sniffs
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    # @TODO Change branch back to master once WPCS + PHPCompatibility are compatible with PHPCS 3.x.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b 2.9 --depth 1 https://github.com/squizlabs/PHP_CodeSniffer.git $PHPCS_DIR; fi
+    # Install WordPress Coding Standards.
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b develop --depth 1 https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git $SNIFFS_DIR; fi
+    # Install PHP Compatibility sniffs.
+    # @TODO ADJUST PATH FOR Composer PR when merged!
+    - if [[ "$SNIFF" == "1" ]]; then git clone -b master --depth 1 https://github.com/wimg/PHPCompatibility.git $SNIFFS_DIR/PHPCompatibility; fi
+    # Set install path for PHPCS sniffs.
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --config-set installed_paths $SNIFFS_DIR; fi
+    # After CodeSniffer install you should refresh your path.
+    - if [[ "$SNIFF" == "1" ]]; then phpenv rehash; fi
 
 
 # Run test script commands.
@@ -51,14 +53,11 @@ before_script:
 script:
     # Search for PHP syntax errors.
     - find -L . -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    # WordPress Coding Standards.
+    # Check code against the WordPress Coding Standards and for PHP cross-version compatibility.
     # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link https://github.com/wimg/phpcompatibility
     # @link http://pear.php.net/package/PHP_CodeSniffer/
-    # -p flag: Show progress of the run.
-    # -s flag: Show sniff codes in all reports.
-    # -v flag: Print verbose output.
-    # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
-    # --standard: Use WordPress as the standard.
-    # --extensions: Only sniff PHP files.
-    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs -p -s -n . --standard=./phpcs.xml --extensions=php; fi
+    # Uses a custom ruleset based on WordPress.
+    # Only fails the build on errors, not warnings, but still show warnings in the output.
+    - if [[ "$SNIFF" == "1" ]]; then $PHPCS_DIR/scripts/phpcs --standard=./phpcs.xml --runtime-set ignore_warnings_on_exit 1; fi
 

--- a/class-debug-bar-screen-info.php
+++ b/class-debug-bar-screen-info.php
@@ -216,15 +216,15 @@ class Debug_Bar_Admin_Screen_Info {
 	 */
 	public function filter_pretty_output_table_body_row( $row, $key ) {
 		$explain = array(
-			'id'			=> __( 'The unique ID of the screen.', 'debug-bar-screen-info' ),
-			'action'		=> __( 'Any action associated with the screen.', 'debug-bar-screen-info' ),
-			'base'			=> __( 'The base type of the screen. This is typically the same as id but with any post types and taxonomies stripped.', 'debug-bar-screen-info' ),
-			'is_network'	=> __( 'Whether this is a multi-site network admin screen.', 'debug-bar-screen-info' ),
-			'is_user'		=> __( 'Whether this is a user admin screen.', 'debug-bar-screen-info' ),
-			'parent_base'	=> __( 'The base menu parent.', 'debug-bar-screen-info' ),
-			'parent_file'	=> __( 'The parent_file for the screen per the admin menu system.', 'debug-bar-screen-info' ),
-			'post_type'		=> __( 'The post type associated with the screen, if any.', 'debug-bar-screen-info' ),
-			'taxonomy'		=> __( 'The taxonomy associated with the screen, if any.', 'debug-bar-screen-info' ),
+			'id'          => __( 'The unique ID of the screen.', 'debug-bar-screen-info' ),
+			'action'      => __( 'Any action associated with the screen.', 'debug-bar-screen-info' ),
+			'base'        => __( 'The base type of the screen. This is typically the same as id but with any post types and taxonomies stripped.', 'debug-bar-screen-info' ),
+			'is_network'  => __( 'Whether this is a multi-site network admin screen.', 'debug-bar-screen-info' ),
+			'is_user'     => __( 'Whether this is a user admin screen.', 'debug-bar-screen-info' ),
+			'parent_base' => __( 'The base menu parent.', 'debug-bar-screen-info' ),
+			'parent_file' => __( 'The parent_file for the screen per the admin menu system.', 'debug-bar-screen-info' ),
+			'post_type'   => __( 'The post type associated with the screen, if any.', 'debug-bar-screen-info' ),
+			'taxonomy'    => __( 'The taxonomy associated with the screen, if any.', 'debug-bar-screen-info' ),
 		);
 
 		$replace = '	<td class="' . esc_attr( $this->plugin_slug ) . '-explain">' . ( isset( $explain[ $key ] ) ? esc_html( $explain[ $key ] ) : '&nbsp;' ) . '

--- a/debug-bar-screen-info.php
+++ b/debug-bar-screen-info.php
@@ -47,10 +47,14 @@ if ( ! function_exists( 'dbsi_has_parent_plugin' ) ) {
 			deactivate_plugins( $file, false, is_network_admin() );
 
 			// Add to recently active plugins list.
+			$insert = array(
+				$file => time(),
+			);
+
 			if ( ! is_network_admin() ) {
-				update_option( 'recently_activated', ( array( $file => time() ) + (array) get_option( 'recently_activated' ) ) );
+				update_option( 'recently_activated', ( $insert + (array) get_option( 'recently_activated' ) ) );
 			} else {
-				update_site_option( 'recently_activated', ( array( $file => time() ) + (array) get_site_option( 'recently_activated' ) ) );
+				update_site_option( 'recently_activated', ( $insert + (array) get_site_option( 'recently_activated' ) ) );
 			}
 
 			// Prevent trying again on page reload.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,14 @@
 <ruleset name="Debug Bar Screeninfo">
 	<description>The code standard for Debug Bar Screeninfo is WordPress.</description>
 
+	<!-- Show progress & sniff codes. -->
+	<arg value="ps"/>
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Check all files in this directory and the directories below it. -->
+	<file>.</file>
+
 	<exclude-pattern>*/inc/debug-bar-pretty-output/*</exclude-pattern>
 
 	<!-- ##### PHP cross-version compatibility ##### -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,10 +18,47 @@
 
 
 	<!-- ##### WordPress sniffs #####-->
-	<rule ref="WordPress" />
+	<rule ref="WordPress">
+		<!-- This is for another day, not now. -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+	</rule>
+
+	<!-- ##### Customizations #####-->
+
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="debug-bar-screen-info" />
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="Debug_Bar,dbsi" />
+		</properties>
+	</rule>
+
+	<!-- Verify that no WP functions are used which are deprecated or have been removed.
+		 The minimum version set here should be in line with the minimum WP version
+		 supported by the Debug Bar extension. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="3.5" />
+		</properties>
+	</rule>
+	<rule ref="WordPress.WP.DeprecatedClasses">
+		<properties>
+			<property name="minimum_supported_version" value="3.5" />
+		</properties>
+	</rule>
 
 
-	<!-- exclude the 'empty' index files from some documentation checks -->
+	<!-- ##### Exlusions #####-->
+
+	<!-- Exclude the 'empty' index files from some documentation checks. -->
 	<rule ref="Squiz.Commenting.FileComment.WrongStyle">
 		<exclude-pattern>*/index.php</exclude-pattern>
 	</rule>


### PR DESCRIPTION
### Update Travis build script
* Include PHP nightly in the build matrix and remove HHVM.
* Use `before_install` rather than `before_script` to better distinguish between failed install or failed build.
* Use the PHPCS `2.9` branch until the external standards are compatible with PHPCS 3.x.
* Use the WPCS `develop` branch to benefit from the latest sniffs.
* Move the standard PHPCS command line arguments to the custom ruleset.
* Show PHPCS warnings, but don't fail the build on it.

### Update the PHPCS ruleset for WPCS 0.12.0
* Exclude one filename rule.
* Verify that the correct text domain is being used.
* Verify that everything in the global namespace is prefixed correctly.
* Verify that no WP deprecated functions or classes are used.

### Minor codestyle fixes