### PR TITLE
Defer to just in time language loading for WP 4.6+.

### DIFF
--- a/class-debug-bar-screen-info.php
+++ b/class-debug-bar-screen-info.php
@@ -110,9 +110,24 @@ class Debug_Bar_Admin_Screen_Info {
 	 *
 	 * Compatible with use of the plugin in the must-use plugins directory.
 	 *
+	 * {@internal No longer needed since WP 4.6, though the language loading in
+	 * WP 4.6 only looks at the `wp-content/languages/` directory and disregards
+	 * any translations which may be included with the plugin.
+	 * This is acceptable for plugins hosted on org, especially if the plugin
+	 * is new and never shipped with it's own translations, but not when the plugin
+	 * is hosted elsewhere.
+	 * Can be removed if/when the minimum required version for this plugin is ever
+	 * upped to 4.6. The `languages` directory can be removed in that case too.
+	 * See: {@link https://core.trac.wordpress.org/ticket/34213} and
+	 * {@link https://core.trac.wordpress.org/ticket/34114} }}
+	 *
 	 * @param string $domain Text domain to load.
 	 */
 	protected function load_textdomain( $domain ) {
+		if ( function_exists( '_load_textdomain_just_in_time' ) ) {
+			return;
+		}
+
 		if ( is_textdomain_loaded( $domain ) ) {
 			return;
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,9 @@ Have you read what it says in the beautiful red bar at the top of your plugins p
 
 == Changelog ==
 
+= Trunk =
+* Defer to just in time loading of translations for WP > 4.5.
+
 = 1.1.5 =
 * Hard-code the text-domain for better compatibility with [GlotPress](https://translate.wordpress.org/projects/wp-plugins/debug-bar-screen-info).
 * Make loading of text-domain compatible with use of the plugin in the `must-use` plugins directory.


### PR DESCRIPTION
When WP 4.6 or higher is used, the `load_plugin_textdomain()` function call is no longer necessary.

As this plugin, however, is also compatible with older WP versions and could still be used to debug older installs, don't remove the language loading completely, nor the languages subdirectory (yet).