### PR TITLE
Fix the link to the Codex and add a link to the Developers reference.

### DIFF
--- a/class-debug-bar-screen-info.php
+++ b/class-debug-bar-screen-info.php
@@ -199,7 +199,7 @@ class Debug_Bar_Admin_Screen_Info {
 		}
 
 		/* TRANSLATORS: %s = the "href" element for the link. */
-		$output .= '<p>' . sprintf( wp_kses_post( __( 'For more information, see the <a %s>Codex on WP_Screen</a>', 'debug-bar-screen-info' ) ), 'href="http://codex.wordpress.org/Class_Reference/WP_Screen" target="_blank" title="' . esc_attr__( 'View the WordPress codex on WP Screen', 'debug-bar-screen-info' ) . '">' ) . '</p>';
+		$output .= '<p>' . wp_kses_post( sprintf( __( 'For more information, see the <a %s>Codex on WP_Screen</a> or the <a %s>Developers Reference</a>.', 'debug-bar-screen-info' ), 'href="http://codex.wordpress.org/Class_Reference/WP_Screen" target="_blank"', 'href="https://developer.wordpress.org/reference/classes/wp_screen/" target="_blank"' ) ) . '</p>';
 
 		return $output;
 	}


### PR DESCRIPTION
The link to the Codex wasn't working anymore due to slightly overzealous output escaping.
Also, as the Developers Reference has since been launched, we might as well link to that as well.